### PR TITLE
fix(gha): add major tag on Publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: haya14busa/action-update-semver@v1
+      with:
+        major_version_tag_only: true
     - name: Create a Release
       uses: actions/create-release@v1
       env:


### PR DESCRIPTION
Hi, 

We don't have major version when a new release is comming. it forces users to update their workflow with the new version. In the case of minors without breaking changes, it will not be a problem to provide a v1 tag (major) that will follow the evolution of the release.


In Github docs, is recommanded to use major tag https://docs.github.com/en/actions/creating-actions/about-custom-actions#using-tags-for-release-management

I add a action  haya14busa/action-update-semver for create a major tag for each release.


If you want we can exchange on this workflow. In my entreprise we worked on release workflow for automaticaly generate release with a lbals bumppr: major| minor| patch, if you are interested I can make you a PR ? 