### PR TITLE
Fix duplicate JSON output

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -46,8 +46,8 @@ fi
 ###############################################
 # Add JSON as Report Format if not present    #
 ###############################################
-if [ ! -z "$INPUT_OUTPUT_FORMATS" ]; then
-    if [[ "json" == *"$INPUT_OUTPUT_FORMATS"* ]]; then
+if [ -n "$INPUT_OUTPUT_FORMATS" ]; then
+    if [[ $INPUT_OUTPUT_FORMATS == *"json"* ]]; then
         OUTPUT_FORMATS_PARAM="--report-formats $INPUT_OUTPUT_FORMATS"
     else
         OUTPUT_FORMATS_PARAM="--report-formats $INPUT_OUTPUT_FORMATS,json"


### PR DESCRIPTION
Using `output_formats: 'json,sarif'`, I see it adds another `json` to Kics:

```log
11:40 - INF : about to scan directory .
11:40 - INF : kics command kics -p . -o results-dir --report-formats json,sarif,json --type Kubernetes       -q /app/bin/assets/queries -v
```

And at the end:

```log
11:40AM INF Results saved to file results-dir/results.json fileName=results.json
Results saved to file results-dir/results.json
11:40AM INF Results saved to file results-dir/results.sarif fileName=results.sarif
Results saved to file results-dir/results.sarif
11:40AM INF Results saved to file results-dir/results.json fileName=results.json
Results saved to file results-dir/results.json
```

It's because wrong Bash condition. Using `[[ $STRING_A == *$STRING_B* ]]` will be true **if `STRING_B` exist in `STRING_A`**.