### PR TITLE
feat: use checkmarx/kics:alpine instead of checkmarx/kics:gh-action

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM checkmarx/kics:gh-action
+FROM checkmarx/kics:alpine
 
 COPY ./entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
Hi, I've noticed that the KICS version of the base image referenced in the Dockerfile is out of date.
This Pull Request will change it to reference the latest alpine image.

I've confirmed that the only difference between the `gh-action` tag and the `v1.5.1-alpine` tag on DockerHub is the terraform provider.
However, the `alpine` tag has the terraform provider fully installed.
Therefore, I believe that the content of this PR is fine.

Related Docker tags:
- [gh-action tag](https://hub.docker.com/layers/kics/checkmarx/kics/gh-action/images/sha256-e05f556cbdd687cb6dbe4f53b0b103398e004d5836abcd920cc85587963fa24b?context=explore)
- [v1.5.1-alpine](https://hub.docker.com/layers/kics/checkmarx/kics/v1.5.1-alpine/images/sha256-4a02cda2e6a1bcf262cfd6b258d9a3a8aedd59e16f78d31fc4fecd7964d9f8a8?context=explore)
- [alpine tag](https://hub.docker.com/layers/kics/checkmarx/kics/alpine/images/sha256-568560ef8ef9a25736b9a828f7d1531e922ffb4973e648745e05fec701affccd?context=explore)

Refs: #48