### PR TITLE
feat: allow to active report as job summary

### DIFF
--- a/.github/workflows/test_action.yaml
+++ b/.github/workflows/test_action.yaml
@@ -20,6 +20,7 @@ jobs:
           output_formats: sarif
           ignore_on_exit: results
           enable_comments: true
+          enable_jobs_summary: true
           comments_with_queries: true
           excluded_column_for_comments_with_queries: "description_id,similarity_id,search_line,search_value,cis_description_id,cis_description_title,cis_description_text,cloud_provider"
       - run: ls -la && ls -la myoutput

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 - [KICS Github Action](#kics-github-action)
   - [Integrate KICS into your GitHub workflows](#integrate-kics-into-your-github-workflows)
-      - [Supported Platforms](#supported-platforms)
+    - [Supported Platforms](#supported-platforms)
     - [Please find more info in the official website: <a href="https://kics.io">kics.io</a>](#please-find-more-info-in-the-official-website-kicsio)
   - [Inputs](#inputs)
   - [Simple usage example](#simple-usage-example)
@@ -74,6 +74,7 @@ And ensure that you're using the <a href="https://github.com/Checkmarx/kics-gith
 | Variable                                  | Example Value &nbsp;                                   | Description &nbsp;                                                                                                                                          | Type    | Required | Default                                                |
 |-------------------------------------------|--------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|---------| -------- |--------------------------------------------------------|
 | enable_comment                            | true                                                   | Enable pull request report comments                                                                                                                         | Boolean | No       | false                                                  |
+| enable_jobs_summary                       | true                                                   | Enable report as jobs summary                                                                                                                               | Boolean | No       | false                                                  |
 | comments_with_queries                     | true                                                   | Add queries in th pull request report comments (available when enable_comments = true)                                                                      | Boolean | No       | false                                                  |
 | excluded_column_for_comments_with_queries | description_id,similarity_id,search_line,search_value  | Excluded columns for the comment with queries, accepts a comma separated list                                                                               | String  | No       | description_id,similarity_id,search_line,search_value  |
 | path                                      | terraform/main.tf,Dockerfile                           | paths to a file or directories to scan, comma separated list                                                                                                | String  | Yes      | N/A                                                    |
@@ -237,16 +238,16 @@ You can only enable one profiler at a time, CPU or MEM.
 
 ```yaml
     steps:
-    - uses: actions/checkout@v3
-    - name: run kics Scan
-      uses: checkmarx/kics-github-action@v1.6
-      with:
-        path: 'terraform'
-        profiling: MEM
-        output_path: myResults/
-    - name: display kics results
-      run: |
-        cat myResults/results.json
+      - uses: actions/checkout@v3
+      - name: run kics Scan
+        uses: checkmarx/kics-github-action@v1.6
+        with:
+          path: 'terraform'
+          profiling: MEM
+          output_path: myResults/
+      - name: display kics results
+        run: |
+          cat myResults/results.json
 ```
 
 ## Uploading SARIF report

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,10 @@ inputs:
     required: false
     default: "false"
     description: "Enable pull request report comments"
+  enable_jobs_summary:
+    required: false
+    default: "false"
+    description: "Enable report as jobs summary"
   comments_with_queries:
     required: false
     default: "false"
@@ -106,6 +110,7 @@ runs:
     INPUT_TOKEN: ${{ inputs.token }}
     INPUT_OUTPUT_PATH: ${{ inputs.output_path }}
     INPUT_ENABLE_COMMENTS: ${{ inputs.enable_comments }}
+    INPUT_ENABLE_JOBS_SUMMARY: ${{ inputs.enable_jobs_summary }}
     INPUT_COMMENTS_WITH_QUERIES: ${{ inputs.comments_with_queries }}
     INPUT_EXCLUDED_COLUMNS_FOR_COMMENTS_WITH_QUERIES: ${{ inputs.excluded_column_for_comments_with_queries }}
     INPUT_OUTPUT_FORMATS: ${{ inputs.output_formats }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "GNU GENERAL PUBLIC LICENSE",
       "dependencies": {
-        "@actions/core": "^1.6.0",
+        "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.0",
         "@actions/github": "^5.0.0",
         "@actions/io": "^1.1.1",
@@ -22,11 +22,28 @@
       }
     },
     "node_modules/@actions/core": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.6.0.tgz",
-      "integrity": "sha512-NB1UAZomZlCV/LmJqkLhNTqtKfFXJZAUPcfl/zqG7EfsQdeUJtaWO98SGbuQ3pydJ3fHl2CvI/51OKYlCYYcaw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-2aZDDa3zrrZbP5ZYg159sNoLRb61nQ7awl5pSvIq5Qpj81vwDzdMRKzkWJGJuwVvWpvZKx7vspJALyvaaIQyug==",
       "dependencies": {
-        "@actions/http-client": "^1.0.11"
+        "@actions/http-client": "^2.0.1",
+        "uuid": "^8.3.2"
+      }
+    },
+    "node_modules/@actions/core/node_modules/@actions/http-client": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.0.1.tgz",
+      "integrity": "sha512-PIXiMVtz6VvyaRsGY268qvj57hXQEpsYogYOu2nrQhlf+XCGmZstmuZBbAybUl1nQGnvS1k1eEsQ69ZoD7xlSw==",
+      "dependencies": {
+        "tunnel": "^0.0.6"
+      }
+    },
+    "node_modules/@actions/core/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@actions/exec": {
@@ -298,11 +315,27 @@
   },
   "dependencies": {
     "@actions/core": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.6.0.tgz",
-      "integrity": "sha512-NB1UAZomZlCV/LmJqkLhNTqtKfFXJZAUPcfl/zqG7EfsQdeUJtaWO98SGbuQ3pydJ3fHl2CvI/51OKYlCYYcaw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-2aZDDa3zrrZbP5ZYg159sNoLRb61nQ7awl5pSvIq5Qpj81vwDzdMRKzkWJGJuwVvWpvZKx7vspJALyvaaIQyug==",
       "requires": {
-        "@actions/http-client": "^1.0.11"
+        "@actions/http-client": "^2.0.1",
+        "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "@actions/http-client": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.0.1.tgz",
+          "integrity": "sha512-PIXiMVtz6VvyaRsGY268qvj57hXQEpsYogYOu2nrQhlf+XCGmZstmuZBbAybUl1nQGnvS1k1eEsQ69ZoD7xlSw==",
+          "requires": {
+            "tunnel": "^0.0.6"
+          }
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+        }
       }
     },
     "@actions/exec": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/Checkmarx/kics-github-action#readme",
   "dependencies": {
-    "@actions/core": "^1.6.0",
+    "@actions/core": "^1.10.0",
     "@actions/exec": "^1.1.0",
     "@actions/github": "^5.0.0",
     "@actions/io": "^1.1.1",

--- a/src/commenter.js
+++ b/src/commenter.js
@@ -1,4 +1,5 @@
 const moment = require('moment')
+const { summary } = require('@actions/core/lib/summary');
 
 const kicsLogo = "https://user-images.githubusercontent.com/74597872/143567454-f65ad285-00d8-4875-845d-568d2e67d868.png"
 const severityOrder = ["HIGH", "MEDIUM", "LOW", "INFO", "TRACE"];
@@ -158,6 +159,12 @@ async function postPRComment(results, repo, prNumber, octokit, commentWithQuerie
     }
 }
 
+async function postJobSummary(results, commentWithQueries = false, excludedColumnsForCommentsWithQueries) {
+    const message = createComment(results, commentWithQueries, excludedColumnsForCommentsWithQueries);
+    await summary.addRaw(message).write()
+}
+
 module.exports = {
-    postPRComment
+    postPRComment,
+    postJobSummary
 };

--- a/src/main.js
+++ b/src/main.js
@@ -48,6 +48,7 @@ async function main() {
     // Get ENV variables
     const githubToken = process.env.INPUT_TOKEN;
     const enableComments = process.env.INPUT_ENABLE_COMMENTS;
+    const enableJobsSummary = process.env.INPUT_ENABLE_JOBS_SUMMARY;
     const commentsWithQueries = process.env.INPUT_COMMENTS_WITH_QUERIES;
     const excludedColumnsForCommentsWithQueries = process.env.INPUT_EXCLUDED_COLUMNS_FOR_COMMENTS_WITH_QUERIES.split(',');
     const outputPath = processOutputPath(process.env.INPUT_OUTPUT_PATH);
@@ -73,6 +74,9 @@ async function main() {
         const parsedResults = readJSON(outputPath.resultsJSONFile);
         if (enableComments.toLocaleLowerCase() === "true") {
             await commenter.postPRComment(parsedResults, repo, prNumber, octokit, commentsWithQueries.toLocaleLowerCase() === "true", excludedColumnsForCommentsWithQueries);
+        }
+        if (enableJobsSummary.toLocaleLowerCase() === "true") {
+            await commenter.postJobSummary(parsedResults, commentsWithQueries.toLocaleLowerCase() === "true", excludedColumnsForCommentsWithQueries);
         }
 
         annotator.annotateChangesWithResults(parsedResults);


### PR DESCRIPTION
Allow to active report as job summary

Exemple of Job summary https://github.blog/2022-05-09-supercharging-github-actions-with-job-summaries/

You can check the result here: https://github.com/Checkmarx/kics-github-action/actions/runs/3385055025