### PR TITLE
ci: pin KICS and wolfi-base by digest, fix config_path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
-FROM checkmarx/kics:v2.1.20 as kics-env
- 
-FROM cgr.dev/chainguard/wolfi-base:latest
- 
+FROM docker.io/checkmarx/kics:v2.1.20@sha256:3e5a268eb8adda2e5a483c9359ddfc4cd520ab856a7076dc0b1d8784a37e2602 AS kics-env
+
+FROM cgr.dev/chainguard/wolfi-base@sha256:70750dfde91b4c5804b4df269121253fbdff73a9122925c7acc067aa33f9f55e
+
 COPY --from=kics-env /app /app
- 
+
 COPY ./entrypoint.sh /entrypoint.sh
- 
+
 RUN chmod +x /entrypoint.sh
- 
+
 COPY ./ /app
- 
+
 ENTRYPOINT ["/entrypoint.sh"]

--- a/action.yml
+++ b/action.yml
@@ -125,7 +125,7 @@ runs:
     - ${{ inputs.fail_on }}
     - ${{ inputs.timeout }}
     - ${{ inputs.profiling }}
-    - ${{ inputs.config }}
+    - ${{ inputs.config_path }}
     - ${{ inputs.platform_type }}
     - ${{ inputs.exclude_paths }}
     - ${{ inputs.exclude_queries }}


### PR DESCRIPTION
## Summary
- Pin `checkmarx/kics` and Chainguard `wolfi-base` by immutable digest in the multistage Dockerfile (mitigates mutable-tag supply-chain risk).
- Fix `runs.args` to use `${{ inputs.config_path }}` so it matches the declared input (replaces invalid `inputs.config`).

## Notes
- `wolfi-base` on cgr.dev only exposes `latest` as a human tag; the digest is the stable identifier (see Chainguard rolling images).
- KICS uses `v2.1.20@sha256:...` for a readable version plus digest.

Digests verified via `crane`
```
crane digest docker.io/checkmarx/kics:v2.1.20
# expect: sha256:3e5a268eb8adda2e5a483c9359ddfc4cd520ab856a7076dc0b1d8784a37e2602
crane digest cgr.dev/chainguard/wolfi-base:latest
# expect: sha256:70750dfde91b4c5804b4df269121253fbdff73a9122925c7acc067aa33f9f55e
```

Made with [Cursor](https://cursor.com)