### PR TITLE
security: digest-pin Dockerfile base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM checkmarx/kics:v2.1.19@sha256:7b0a4d750acd491942ce9de52c1183fbf4451c1c936780ec2cfacd2650e7d84c as kics-env
+FROM docker.io/checkmarx/kics:v2.1.19@sha256:7b0a4d750acd491942ce9de52c1183fbf4451c1c936780ec2cfacd2650e7d84c AS kics-env
 
 FROM cgr.dev/chainguard/wolfi-base:latest@sha256:70750dfde91b4c5804b4df269121253fbdff73a9122925c7acc067aa33f9f55e
  

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM checkmarx/kics:v2.1.20 as kics-env
- 
-FROM cgr.dev/chainguard/wolfi-base:latest
+FROM checkmarx/kics:v2.1.19@sha256:7b0a4d750acd491942ce9de52c1183fbf4451c1c936780ec2cfacd2650e7d84c as kics-env
+
+FROM cgr.dev/chainguard/wolfi-base:latest@sha256:70750dfde91b4c5804b4df269121253fbdff73a9122925c7acc067aa33f9f55e
  
 COPY --from=kics-env /app /app
  


### PR DESCRIPTION
Pin both FROM images by SHA256 digest so a repushed/poisoned tag on the upstream registry cannot flow into the Action build. SHA-pinning the GitHub Action alone is insufficient because the Docker image tag remains mutable on Docker Hub.

I've downgraded kics to version 2.1.19 for now:
  - checkmarx/kics: v2.1.20 -> v2.1.19 -> sha256
  - cgr.dev/chainguard/wolfi-base:latest -> sha256

The tag is kept alongside the digest as a human-readable intent marker; 
Docker resolves the pull by digest, so a mismatched tag republish fails closed instead of silently substituting content.

Thanks to @bsgrigorov and everyone involved for bringing this issue to our attention.